### PR TITLE
Fixed scanning for images after VRChat update

### DIFF
--- a/VRQR/Form1.cs
+++ b/VRQR/Form1.cs
@@ -25,6 +25,8 @@ namespace VRQR
             watcher.Filter = "*.png";
             watcher.Created += fileCreatedEvent;
             watcher.EnableRaisingEvents = true;
+            // Scan subdirectories - Credit to Hazel-Willow for fix - github.com/Frostion/VRQR/issues/1#issuecomment-1008435172
+            watcher.IncludeSubdirectories = true;  
         }
         private void Form1_Load(object sender, EventArgs e)
         {


### PR DESCRIPTION
After VRChat updated to build 1149, new photos were organized into subfolders. This fix scans those subfolders for pictures containing QR codes. Credit to Hazel-Willow for providing this solution, all I've done is make their fix into a pull request.
I have tested this change and can confirm it is functional. 